### PR TITLE
Added solution to undefined reference to 'net_config_init_app'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,9 @@ Maybe cmake, missing binaries, configuration ?
 
 Waiting, I'm setting `CONFIG_NET_CONFIG_AUTO_INIT=y` and don't calling these functions.
 
+SOLUTION:
+Add `CONFIG_NET_CONFIG_SETTINGS=y`
+
 ### 002. <err> os: CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE is 0
 
 Need


### PR DESCRIPTION
Hi, found it :-) This solution is valid for zephyr version 2.7.
